### PR TITLE
Fjernet taskId fra taskcontroller

### DIFF
--- a/src/main/java/org/example/eksamenkea/controller/TaskController.java
+++ b/src/main/java/org/example/eksamenkea/controller/TaskController.java
@@ -66,20 +66,32 @@ public class TaskController {
     //DELETE-----------------------------------------------------------------
     //Vise bekræftelsessiden
     @GetMapping("/confirm-delete-task")
-    public String showConfirmDeleteTask(@RequestParam("taskId") int taskId, @RequestParam("subprojectName") String subprojectName, HttpSession session, Model model) throws Errorhandling {
-        // Tilføj taskId og subprojectName til modellen
+    public String showConfirmDeleteTask(@RequestParam("taskName") String taskName, @RequestParam("subprojectName") String subprojectName, HttpSession session, Model model) throws Errorhandling {
+        //  hente taskId
+        int taskId = taskService.getTaskIdByTaskName(taskName);
+
+        //  taskId og subprojectName tilføjes til modellen
         model.addAttribute("taskId", taskId);
         model.addAttribute("subprojectName", subprojectName);
+        model.addAttribute("taskName", taskName);
         return "confirm-delete-task";
     }
 
-    //metode til at slette task
+
+    // Metode til at slette task
     @PostMapping("/delete-task")
-    public String deleteTask(@RequestParam("taskId") int taskId, @RequestParam("subprojectName") String subprojectName, HttpSession session, Model model) throws Errorhandling {
+    public String deleteTask(@RequestParam("taskName") String taskName, @RequestParam("subprojectName") String subprojectName,
+            HttpSession session) throws Errorhandling {
+        // Hent taskId baseret på taskName
+        int taskId = taskService.getTaskIdByTaskName(taskName);
+
+        // Hent employeeId fra session
         int employeeId = (int) session.getAttribute("employeeId");
+
+        // Slet task baseret på taskId og employeeId
         taskService.deleteTaskById(taskId, employeeId);
 
-        // Returnér til Task Overview med subprojectName
+        // Returner til Task Overview med subprojectName
         return "redirect:/project-leader-tasks?subprojectName=" + subprojectName;
     }
 }

--- a/src/main/java/org/example/eksamenkea/repository/TaskRepository.java
+++ b/src/main/java/org/example/eksamenkea/repository/TaskRepository.java
@@ -106,6 +106,7 @@ public class TaskRepository implements ITaskRepository {
         return tasks;
     }
 
+    @Override
     public int getTaskIdByTaskName(String taskName) throws Errorhandling {
         String query = "SELECT task_id FROM task WHERE task_name = ?";
 
@@ -126,14 +127,6 @@ public class TaskRepository implements ITaskRepository {
         }
     }
 
-
-
-
-    public void deleteTaskByID(int taskId) throws Errorhandling {
-        String query = "DELETE FROM task WHERE task_id = ?";
-
-
-    }
 
 
     @Override
@@ -206,4 +199,7 @@ public class TaskRepository implements ITaskRepository {
         String editwishSql = "DELETE FROM employee_task WHERE task_id = ?";
 
     }
+
+
+
 }

--- a/src/main/java/org/example/eksamenkea/repository/interfaces/ISubprojectRepository.java
+++ b/src/main/java/org/example/eksamenkea/repository/interfaces/ISubprojectRepository.java
@@ -1,0 +1,9 @@
+package org.example.eksamenkea.repository.interfaces;
+
+import org.example.eksamenkea.service.Errorhandling;
+
+public interface ISubprojectRepository {
+
+    int getSubprojectIdBySubprojectName(String subprojectName) throws Errorhandling;
+
+}

--- a/src/main/java/org/example/eksamenkea/repository/interfaces/ITaskRepository.java
+++ b/src/main/java/org/example/eksamenkea/repository/interfaces/ITaskRepository.java
@@ -14,11 +14,12 @@ public interface ITaskRepository {
 
     List<Task> getTasklistByEmployeeId(int employeeId) throws Errorhandling;
 
-    void deleteTaskByID(int taskId) throws Errorhandling;
 
     void createTask(Task task) throws Errorhandling;
 
     void deleteTaskById(int taskId, int employeeId) throws Errorhandling;
 
     void updateTask(Task task) throws Errorhandling;
+
+    int getTaskIdByTaskName(String taskName) throws Errorhandling;
 }

--- a/src/main/java/org/example/eksamenkea/service/TaskService.java
+++ b/src/main/java/org/example/eksamenkea/service/TaskService.java
@@ -35,7 +35,12 @@ public class TaskService {
     public void createTask(Task task) throws Errorhandling {
         taskRepository.createTask(task);
     }
+
     public void deleteTaskById(int taskId, int employeeId) throws Errorhandling {
-        taskRepository.deleteTaskById(taskId,employeeId);
+        taskRepository.deleteTaskById(taskId, employeeId);
+    }
+
+    public int getTaskIdByTaskName(String taskName) throws Errorhandling {
+        return taskRepository.getTaskIdByTaskName(taskName);
     }
 }

--- a/src/main/resources/templates/confirm-delete-task.html
+++ b/src/main/resources/templates/confirm-delete-task.html
@@ -9,13 +9,13 @@
 <h1>Confirm Delete Task</h1>
 <p>Are you sure you want to delete the task with ID: <span th:text="${taskId}"></span>?</p>
 <form th:action="@{/delete-task}" method="post">
-    <input type="hidden" name="taskId" th:value="${taskId}">
-    <input type="hidden" name="subprojectName" th:value="${subprojectName}"> <!-- Sørg for, at denne ikke er null -->
-    <button type="submit" class="btn btn-danger">Confirm Delete</button>
+    <input type="hidden" name="taskName" th:value="${taskName}">
+    <input type="hidden" name="subprojectName" th:value="${subprojectName}">
+    <button type="submit">Confirm Delete</button>
 </form>
 
 
-<a th:href="@{'/project-leader-tasks?subprojectName=' + ${subprojectName}}" class="btn">Cancel</a> <!-- Tilføjet subprojectName -->
+<a th:href="@{'/project-leader-tasks?subprojectName=' + ${subprojectName}}" >Cancel</a>
 
 </body>
 </html>

--- a/src/main/resources/templates/project-leader-task-overview.html
+++ b/src/main/resources/templates/project-leader-task-overview.html
@@ -30,7 +30,7 @@
         <td th:text="${task.actual_hours}"></td>
         <td>
             <!-- Link til bekræftelsesside -->
-            <a th:href="@{'/confirm-delete-task?taskId=' + ${task.task_id} + '&subprojectName=' + ${subprojectName}}" class="btn btn-danger">Delete</a>
+            <a th:href="@{'/confirm-delete-task?taskName=' + ${task.task_name} + '&subprojectName=' + ${subprojectName}}">Delete</a>
 
         </td>
     </tr>


### PR DESCRIPTION
Tilføjet getTaskIdByTaskName-metode til at hente task ID baseret på task name og integreret den i delete-controller-metoderne. Controlleren kræver nu kun taskName, og taskId hentes dynamisk

#72 